### PR TITLE
next.config.tsでoutputの設定を有効化し、Workページに静的パラメータ生成関数を追加

### DIFF
--- a/app/work/[workId]/page.tsx
+++ b/app/work/[workId]/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { motion } from "framer-motion";
 import { FaLightbulb, FaImages } from "react-icons/fa";
 import Image from "next/image";
@@ -8,6 +7,13 @@ import { GrTechnology } from "react-icons/gr";
 import { IoMdPerson } from "react-icons/io";
 import { PiProjectorScreen } from "react-icons/pi";
 import { use } from "react";
+
+// 既存のコードの前に追加
+export async function generateStaticParams() {
+  return projectsData.map((project) => ({
+    workId: project.slug,
+  }));
+}
 
 type SectionProps = {
   title: string;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // output: "export",
+  output: "export",
   // images: {
   //   unoptimized: true, // これを追加！
   // },


### PR DESCRIPTION
## エラーの原因
- 動的ルーティング（[workId]）を使用しているページで、`generateStaticParams()`関数が定義されていない
- 静的エクスポートを使用する場合、ビルド時にすべての動的ルートのパスを事前に生成する必要がある
## `"use client"`を削除

- 必要ないのと、むしろ、静的エクスポート`（output: export）`を使用する場合、`"use client"`を削除推奨